### PR TITLE
Add extra data to wrapLambda call

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,10 @@ module.exports = function(options) {
       const funcConf = slsConf.functions[funcId];
       let func = getObjectPath(funcConf.handler, slsHandlers);
       if (httpConfig.wrapLambda) {
-        func = httpConfig.wrapLambda(func);
+        func = httpConfig.wrapLambda(func, {
+          lambdaName: funcId,
+          serviceName: slsConf.service,
+        });
       }
       service[funcId] = func;
       // http event source setup


### PR DESCRIPTION
This adds lambda and service name to the wrapLambda call so that
a user can identify the lambda. This can be useful, for example,
if you want to log automatically in the wrapper.
